### PR TITLE
Update FDS_User_Guide.tex

### DIFF
--- a/Manuals/FDS_User_Guide/FDS_User_Guide.tex
+++ b/Manuals/FDS_User_Guide/FDS_User_Guide.tex
@@ -12262,7 +12262,7 @@ Keyword             & Type     & Description                      & Units       
 \ct{SMOOTHING_TIME}       & Real            & Section~\ref{info:basic_control}                                & s     &               \\ \hline
 \ct{SPATIAL_STATISTIC}    & Character       & Section~\ref{info:statistics}                                   &       &               \\ \hline
 \ct{SPEC_ID}              & Character       & Section~\ref{info:gasoutputquantities}                          &       &               \\ \hline
-\ct{STATISTICS_END}       & Real            & Section~\ref{info:rmscovcorr}                                   & s     & \ct{T_BEGIN}\\ \hline
+\ct{STATISTICS_END}       & Real            & Section~\ref{info:rmscovcorr}                                   & s     & \ct{T_END}\\ \hline
 \ct{STATISTICS_START}     & Real            & Section~\ref{info:rmscovcorr}                                   & s     & \ct{T_BEGIN}\\ \hline
 \ct{SURF_ID}              & Character       & Section~\ref{info:statistics}                                   &       &               \\ \hline
 \ct{TEMPORAL_STATISTIC}   & Character       & Section~\ref{info:statistics}                                   &       &               \\ \hline


### PR DESCRIPTION
There is an error in the user manual for STATISTICS_END on page 417, it states that the default value is T_BEGIN, where the actual value is T_END. I also checked it by running a simulation.